### PR TITLE
🚣 [dd] environment variables with API/App keys override need for 1password

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,6 +3,7 @@
     "allow": [
       "Bash(./datadog-service-analyzer.sh:*)",
       "Bash(./service-team-mapper.sh:*)",
+      "Bash(just claude_review *)",
       "Bash(markdownlint-cli2:*)",
       "Bash(shellcheck:*)"
     ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,16 @@ Both bash scripts follow this pattern:
 
 ### Credential management
 
+Credentials are resolved in order: environment variables first, then 1Password.
+
+**Environment variables** (standard Datadog names):
+
+- `DD_API_KEY` - Datadog API key
+- `DD_APP_KEY` - Datadog application key
+- `DD_SITE` - Datadog site (optional, defaults to `datadoghq.com`)
+
+**1Password fallback** (used when `DD_API_KEY`/`DD_APP_KEY` are not set):
+
 Scripts expect 1Password items with these fields:
 
 - `api_key` - Datadog API key

--- a/datadog-service-analyzer.sh
+++ b/datadog-service-analyzer.sh
@@ -79,16 +79,26 @@ check_dependencies() {
 }
 
 get_credentials_from_env() {
+    { local restore_trace=false; [[ $- == *x* ]] && restore_trace=true; set +x; } 2>/dev/null
     if [[ -n "${DD_API_KEY:-}" && -n "${DD_APP_KEY:-}" ]]; then
+        if [[ "${DD_API_KEY}" == *"|"* || "${DD_APP_KEY}" == *"|"* ]]; then
+            log_error "DD_API_KEY and DD_APP_KEY must not contain '|'"
+            exit 1
+        fi
         local site="${DD_SITE:-datadoghq.com}"
         log_info "Using credentials from environment variables"
         echo "${DD_API_KEY}|${DD_APP_KEY}|${site}"
+        { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
         return 0
+    elif [[ -n "${DD_API_KEY:-}" || -n "${DD_APP_KEY:-}" ]]; then
+        log_warn "Only one of DD_API_KEY/DD_APP_KEY is set — both required to skip 1Password. Falling back to 1Password."
     fi
+    { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
     return 1
 }
 
 get_credentials_from_1password() {
+    { local restore_trace=false; [[ $- == *x* ]] && restore_trace=true; set +x; } 2>/dev/null
     local vault="${1:-datadog}"
     local item="${2:-datadog-api}"
 
@@ -116,6 +126,7 @@ get_credentials_from_1password() {
     site=$(op item get "$item" --vault "$vault" --field "site" 2>/dev/null || echo "datadoghq.com")
 
     echo "$api_key|$app_key|$site"
+    { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
 }
 
 make_datadog_request() {
@@ -321,7 +332,9 @@ main() {
         credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
     fi
 
+    { local _xt=false; [[ $- == *x* ]] && _xt=true; set +x; } 2>/dev/null
     IFS='|' read -r api_key app_key site <<< "$credentials"
+    { [[ "$_xt" == "true" ]] && set -x; } 2>/dev/null
     
     local telemetry_services
     telemetry_services=$(get_services_from_telemetry "$api_key" "$app_key" "$site" "$days")

--- a/datadog-service-analyzer.sh
+++ b/datadog-service-analyzer.sh
@@ -41,29 +41,36 @@ OPTIONS:
     --op-item ITEM         1Password item name [default: datadog-api]
     --days DAYS            Days of telemetry data to analyze [default: 7]
 
+ENVIRONMENT VARIABLES:
+    DD_API_KEY              Datadog API key (overrides 1Password)
+    DD_APP_KEY              Datadog application key (overrides 1Password)
+    DD_SITE                 Datadog site [default: datadoghq.com]
+
 EXAMPLES:
     $SCRIPT_NAME
     $SCRIPT_NAME --output json --days 14
     $SCRIPT_NAME --op-vault production --op-item datadog-prod
+    DD_API_KEY=xxx DD_APP_KEY=yyy $SCRIPT_NAME
 
 EOF
 }
 
 check_dependencies() {
+    local need_op="$1"
     local missing_deps=()
-    
-    if ! command -v op &> /dev/null; then
+
+    if [[ "$need_op" == "true" ]] && ! command -v op &> /dev/null; then
         missing_deps+=("1Password CLI (op)")
     fi
-    
+
     if ! command -v curl &> /dev/null; then
         missing_deps+=("curl")
     fi
-    
+
     if ! command -v jq &> /dev/null; then
         missing_deps+=("jq")
     fi
-    
+
     if [[ ${#missing_deps[@]} -gt 0 ]]; then
         log_error "Missing required dependencies:"
         printf '  - %s\n' "${missing_deps[@]}" >&2
@@ -71,33 +78,43 @@ check_dependencies() {
     fi
 }
 
+get_credentials_from_env() {
+    if [[ -n "${DD_API_KEY:-}" && -n "${DD_APP_KEY:-}" ]]; then
+        local site="${DD_SITE:-datadoghq.com}"
+        log_info "Using credentials from environment variables"
+        echo "${DD_API_KEY}|${DD_APP_KEY}|${site}"
+        return 0
+    fi
+    return 1
+}
+
 get_credentials_from_1password() {
     local vault="${1:-datadog}"
     local item="${2:-datadog-api}"
-    
+
     log_info "Retrieving credentials from 1Password vault: $vault, item: $item"
-    
+
     if ! op vault get "$vault" &>/dev/null; then
         log_error "Cannot access 1Password vault: $vault"
         exit 1
     fi
-    
+
     local api_key
     local app_key
     local site
-    
+
     api_key=$(op item get "$item" --vault "$vault" --field "api_key" 2>/dev/null || {
         log_error "Failed to retrieve api_key from 1Password"
         exit 1
     })
-    
+
     app_key=$(op item get "$item" --vault "$vault" --field "app_key" 2>/dev/null || {
         log_error "Failed to retrieve app_key from 1Password"
         exit 1
     })
-    
+
     site=$(op item get "$item" --vault "$vault" --field "site" 2>/dev/null || echo "datadoghq.com")
-    
+
     echo "$api_key|$app_key|$site"
 }
 
@@ -295,12 +312,15 @@ main() {
     if [[ "$verbose" == "true" ]]; then
         set -x
     fi
-    
-    check_dependencies
-    
+
     local credentials
-    credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
-    
+    if credentials=$(get_credentials_from_env); then
+        check_dependencies false
+    else
+        check_dependencies true
+        credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
+    fi
+
     IFS='|' read -r api_key app_key site <<< "$credentials"
     
     local telemetry_services

--- a/service-team-mapper.sh
+++ b/service-team-mapper.sh
@@ -40,29 +40,36 @@ OPTIONS:
     --op-vault VAULT       1Password vault name [default: datadog]
     --op-item ITEM         1Password item name [default: datadog-api]
 
+ENVIRONMENT VARIABLES:
+    DD_API_KEY              Datadog API key (overrides 1Password)
+    DD_APP_KEY              Datadog application key (overrides 1Password)
+    DD_SITE                 Datadog site [default: datadoghq.com]
+
 EXAMPLES:
     $SCRIPT_NAME
     $SCRIPT_NAME --output table
     $SCRIPT_NAME --op-vault production --op-item datadog-prod
+    DD_API_KEY=xxx DD_APP_KEY=yyy $SCRIPT_NAME
 
 EOF
 }
 
 check_dependencies() {
+    local need_op="$1"
     local missing_deps=()
-    
-    if ! command -v op &> /dev/null; then
+
+    if [[ "$need_op" == "true" ]] && ! command -v op &> /dev/null; then
         missing_deps+=("1Password CLI (op)")
     fi
-    
+
     if ! command -v curl &> /dev/null; then
         missing_deps+=("curl")
     fi
-    
+
     if ! command -v jq &> /dev/null; then
         missing_deps+=("jq")
     fi
-    
+
     if [[ ${#missing_deps[@]} -gt 0 ]]; then
         log_error "Missing required dependencies:"
         printf '  - %s\n' "${missing_deps[@]}" >&2
@@ -70,33 +77,43 @@ check_dependencies() {
     fi
 }
 
+get_credentials_from_env() {
+    if [[ -n "${DD_API_KEY:-}" && -n "${DD_APP_KEY:-}" ]]; then
+        local site="${DD_SITE:-datadoghq.com}"
+        log_info "Using credentials from environment variables"
+        echo "${DD_API_KEY}|${DD_APP_KEY}|${site}"
+        return 0
+    fi
+    return 1
+}
+
 get_credentials_from_1password() {
     local vault="${1:-datadog}"
     local item="${2:-datadog-api}"
-    
+
     log_info "Retrieving credentials from 1Password vault: $vault, item: $item"
-    
+
     if ! op vault get "$vault" &>/dev/null; then
         log_error "Cannot access 1Password vault: $vault"
         exit 1
     fi
-    
+
     local api_key
     local app_key
     local site
-    
+
     api_key=$(op item get "$item" --vault "$vault" --field "api_key" 2>/dev/null || {
         log_error "Failed to retrieve api_key from 1Password"
         exit 1
     })
-    
+
     app_key=$(op item get "$item" --vault "$vault" --field "app_key" 2>/dev/null || {
         log_error "Failed to retrieve app_key from 1Password"
         exit 1
     })
-    
+
     site=$(op item get "$item" --vault "$vault" --field "site" 2>/dev/null || echo "datadoghq.com")
-    
+
     echo "$api_key|$app_key|$site"
 }
 
@@ -273,12 +290,15 @@ main() {
     if [[ "$verbose" == "true" ]]; then
         set -x
     fi
-    
-    check_dependencies
-    
+
     local credentials
-    credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
-    
+    if credentials=$(get_credentials_from_env); then
+        check_dependencies false
+    else
+        check_dependencies true
+        credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
+    fi
+
     IFS='|' read -r api_key app_key site <<< "$credentials"
     
     local mappings

--- a/service-team-mapper.sh
+++ b/service-team-mapper.sh
@@ -78,16 +78,26 @@ check_dependencies() {
 }
 
 get_credentials_from_env() {
+    { local restore_trace=false; [[ $- == *x* ]] && restore_trace=true; set +x; } 2>/dev/null
     if [[ -n "${DD_API_KEY:-}" && -n "${DD_APP_KEY:-}" ]]; then
+        if [[ "${DD_API_KEY}" == *"|"* || "${DD_APP_KEY}" == *"|"* ]]; then
+            log_error "DD_API_KEY and DD_APP_KEY must not contain '|'"
+            exit 1
+        fi
         local site="${DD_SITE:-datadoghq.com}"
         log_info "Using credentials from environment variables"
         echo "${DD_API_KEY}|${DD_APP_KEY}|${site}"
+        { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
         return 0
+    elif [[ -n "${DD_API_KEY:-}" || -n "${DD_APP_KEY:-}" ]]; then
+        log_warn "Only one of DD_API_KEY/DD_APP_KEY is set — both required to skip 1Password. Falling back to 1Password."
     fi
+    { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
     return 1
 }
 
 get_credentials_from_1password() {
+    { local restore_trace=false; [[ $- == *x* ]] && restore_trace=true; set +x; } 2>/dev/null
     local vault="${1:-datadog}"
     local item="${2:-datadog-api}"
 
@@ -115,6 +125,7 @@ get_credentials_from_1password() {
     site=$(op item get "$item" --vault "$vault" --field "site" 2>/dev/null || echo "datadoghq.com")
 
     echo "$api_key|$app_key|$site"
+    { [[ "$restore_trace" == "true" ]] && set -x; } 2>/dev/null
 }
 
 make_datadog_request() {
@@ -299,7 +310,9 @@ main() {
         credentials=$(get_credentials_from_1password "$op_vault" "$op_item")
     fi
 
+    { local _xt=false; [[ $- == *x* ]] && _xt=true; set +x; } 2>/dev/null
     IFS='|' read -r api_key app_key site <<< "$credentials"
+    { [[ "$_xt" == "true" ]] && set -x; } 2>/dev/null
     
     local mappings
     mappings=$(get_service_team_mappings "$api_key" "$app_key" "$site")


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🚣 [dd] environment variables with API/App keys override need for 1password
- fixes for code review
- claude can see its own code reviews

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)

